### PR TITLE
Updated dependency for M1 Mac builds

### DIFF
--- a/SignalCoreKit.podspec
+++ b/SignalCoreKit.podspec
@@ -38,7 +38,7 @@ A Swift & Objective-C library used by other Signal libraries.
   s.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC' }
 
   s.dependency 'CocoaLumberjack'
-  s.dependency 'GRKOpenSSLFramework'
+  s.dependency 'OpenSSL-Universal'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'SignalCoreKitTests/src/**/*.{h,m,swift}'


### PR DESCRIPTION
Updated the GRKOpenSSLFramework dependency to allow building on an M1 Mac